### PR TITLE
Add make.inc template for NAG Fortran Compiler

### DIFF
--- a/make.inc.nag
+++ b/make.inc.nag
@@ -1,0 +1,30 @@
+WARNFLAGS = -Wall -Wextra
+
+# M1
+#FORTRAN_DIR = /opt/homebrew/Cellar/gcc/12.2.0/lib/gcc/current
+# Linux x86_64
+#FORTRAN_DIR = /usr/lib/gcc/x86_64-linux-gnu/11
+
+#FORTRAN_LIBS = -L$(FORTRAN_DIR) -lgfortran
+# M1
+# symlink ISO_Fortran_binding.h from $(FORTRAN_DIR)/gcc/aarch64-apple-darwin21/11/include to . because reasons
+#FORTRAN_INCLUDE = -I.
+# Linux GCC-12
+#FORTRAN_INCLUDE = -I/usr/lib/gcc/x86_64-linux-gnu/12/include/
+
+FC = nagfor
+FCFLAGS = -g -f2018 -DHAVE_CFI
+
+NAG_ROOT_DIR = $(dir $(FC))
+FORTRAN_INCLUDE = -I$(NAG_ROOT_DIR)/lib
+
+MPI_LIBS = -L$(OPENMPI_LIB_DIR) -lmpi
+#MPI_LIBS = -g -Wl,-commons,use_dylibs -I/opt/homebrew/Cellar/mpich/4.0.2_1/include -L/opt/homebrew/Cellar/mpich/4.0.2_1/lib -lmpi -lpmpi
+#MPI_LIBS = -g -L/opt/homebrew/Cellar/open-mpi/4.1.4_2/lib -L/opt/homebrew/opt/libevent/lib -lmpi
+
+# M1
+CC = mpicc
+CFLAGS = $(WARNFLAGS) -g -std=c11 $(FORTRAN_INCLUDE) -DHAVE_CFI
+
+#ABIFLAG = -DMPICH
+ABIFLAG = -DOPEN_MPI


### PR DESCRIPTION
Assumes that `OPENMPI_LIB_DIR` is set. It also assumes GNU Make as the `dir` function is used to infer the directory where the <ISO_Fortran_binding.h> is located.